### PR TITLE
:+1: 一件目のテストとして取引のテストを追加

### DIFF
--- a/code/build.gradle.kts
+++ b/code/build.gradle.kts
@@ -18,14 +18,15 @@ repositories {
 }
 
 dependencies {
-    testImplementation(kotlin("test"))
     implementation("io.ktor:ktor-server-netty:1.6.3")
     implementation("io.ktor:ktor-html-builder:1.6.3")
     implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:0.7.2")
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.8.0")
 }
 
 tasks.test {
-    useJUnit()
+    useJUnitPlatform()
 }
 
 tasks.withType<KotlinCompile> {

--- a/code/src/test/kotlin/domain/main_books/TransactionsTest.kt
+++ b/code/src/test/kotlin/domain/main_books/TransactionsTest.kt
@@ -1,0 +1,72 @@
+package domain.main_books
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+
+
+internal class TransactionsTest {
+
+    @Test
+    fun testVerify_Success() {
+        assertDoesNotThrow {
+            Transactions(
+                date = LocalDate.of(2023, 1, 1),
+                accountItemList = listOf(
+                    AccountItem(
+                        transactionSide = TransactionSide.Debit,
+                        titleOfAccount = "電気代",
+                        amount = 10000,
+                        generalLedgerPage = null,
+                    ),
+                    AccountItem(
+                        transactionSide = TransactionSide.Credit,
+                        titleOfAccount = "現金",
+                        amount = 10000,
+                        generalLedgerPage = null,
+                    )
+                ),
+                explanation = "電気代10,000円、現金で支払い"
+            )
+        }
+    }
+
+    @Test
+    fun testVerify_Failure_empty_account() {
+        assertThrows<IllegalStateException> {
+            Transactions(
+                date = LocalDate.of(2023, 1, 1),
+                accountItemList = emptyList(),
+                explanation = "電気代10,000円、現金で支払い"
+            )
+        }
+    }
+
+    @Test
+    fun testVerify_Failure_unbalance() {
+        assertThrows<IllegalStateException> {
+            Transactions(
+                date = LocalDate.of(2023, 1, 1),
+                accountItemList = listOf(
+                    AccountItem(
+                        transactionSide = TransactionSide.Debit,
+                        titleOfAccount = "電気代",
+                        amount = 9000,
+                        generalLedgerPage = null,
+                    ),
+                    AccountItem(
+                        transactionSide = TransactionSide.Credit,
+                        titleOfAccount = "現金",
+                        amount = 10000,
+                        generalLedgerPage = null,
+                    )
+                ),
+                explanation = "電気代10,000円、現金で支払い"
+            )
+        }
+    }
+
+
+
+}


### PR DESCRIPTION
## 概要

- テストを追加
- モデルベースで異常系を定義している取引クラスをベースにテスト実施